### PR TITLE
Add quick-blastp option to in-app NCBI BLAST workflow

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,6 +103,7 @@ export default tseslint.config(
       ],
 
       'unicorn/no-null': 'off',
+      'unicorn/no-nested-ternary': 'off',
 
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',

--- a/src/AddHighlightModel/GenomeMouseoverHighlight.tsx
+++ b/src/AddHighlightModel/GenomeMouseoverHighlight.tsx
@@ -7,7 +7,7 @@ import { useStyles } from './util'
 
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
-const GenomeMouseoverHighlight = observer(function GenomeMouseoverHighlight2({
+const GenomeMouseoverHighlight = observer(function ({
   model,
 }: {
   model: LinearGenomeViewModel
@@ -16,11 +16,11 @@ const GenomeMouseoverHighlight = observer(function GenomeMouseoverHighlight2({
   return hovered &&
     typeof hovered === 'object' &&
     'hoverPosition' in hovered ? (
-    <HoverHighlight model={model} />
+    <GenomeMouseoverHighlightPostNullCheck model={model} />
   ) : null
 })
 
-const HoverHighlight = observer(function HoverHighlight2({
+const GenomeMouseoverHighlightPostNullCheck = observer(function ({
   model,
 }: {
   model: LinearGenomeViewModel

--- a/src/AddHighlightModel/MsaToGenomeHighlight.tsx
+++ b/src/AddHighlightModel/MsaToGenomeHighlight.tsx
@@ -42,8 +42,9 @@ const MsaToGenomeHighlight = observer(function MsaToGenomeHighlight2({
               style={{ left, width }}
             />
           )
+        } else {
+          return null
         }
-        return null
       })}
     </>
   ) : null

--- a/src/LaunchMsaView/components/ManualMSALoader/launchView.ts
+++ b/src/LaunchMsaView/components/ManualMSALoader/launchView.ts
@@ -25,10 +25,10 @@ export function launchView({
   session.addView('MsaView', {
     type: 'MsaView',
     displayName: newViewTitle,
+    connectedViewId: view.id,
+    connectedFeature: feature.toJSON(),
     msaFileLocation,
     treeFileLocation,
     data,
-    connectedViewId: view.id,
-    connectedFeature: feature.toJSON(),
   })
 }

--- a/src/LaunchMsaView/components/NCBIBlastQuery/NCBIBlastManualPanel.tsx
+++ b/src/LaunchMsaView/components/NCBIBlastQuery/NCBIBlastManualPanel.tsx
@@ -6,6 +6,7 @@ import { Button, DialogActions, DialogContent, Typography } from '@mui/material'
 import { observer } from 'mobx-react'
 import { makeStyles } from 'tss-react/mui'
 
+import ExternalLink from '../../../ExternalLink'
 import { getId, getTranscriptFeatures } from '../../util'
 import TranscriptSelector from '../TranscriptSelector'
 import { useFeatureSequence } from '../useFeatureSequence'
@@ -20,6 +21,11 @@ const useStyles = makeStyles()({
   textAreaFont: {
     fontFamily: 'Courier New',
   },
+  ncbiLink: {
+    wordBreak: 'break-all',
+    margin: 30,
+    maxWidth: 600,
+  },
 })
 
 const NCBIBlastManualPanel = observer(function ({
@@ -27,10 +33,12 @@ const NCBIBlastManualPanel = observer(function ({
   feature,
   model,
   children,
+  baseUrl,
 }: {
   children: React.ReactNode
   model: AbstractTrackModel
   feature: Feature
+  baseUrl: string
   handleClose: () => void
 }) {
   const { classes } = useStyles()
@@ -43,8 +51,9 @@ const NCBIBlastManualPanel = observer(function ({
     feature: selectedTranscript,
   })
 
-  const link = `https://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastSearch&PAGE=Proteins&PROGRAM=blastp&QUERY=${proteinSequence}`
-  const link2 = `https://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastSearch&PAGE=Proteins&PROGRAM=blastp&QUERY=${shorten2(proteinSequence, 10)}`
+  const s2 = proteinSequence.replaceAll('*', '').replaceAll('&', '')
+  const link = `${baseUrl}?PAGE_TYPE=BlastSearch&PAGE=Proteins&PROGRAM=blastp&QUERY=${s2}`
+  const link2 = `${baseUrl}?PAGE_TYPE=BlastSearch&PAGE=Proteins&PROGRAM=blastp&QUERY=${shorten2(s2, 10)}`
 
   return (
     <>
@@ -61,11 +70,8 @@ const NCBIBlastManualPanel = observer(function ({
         />
 
         {proteinSequence ? (
-          <div style={{ wordBreak: 'break-all', margin: 30, maxWidth: 600 }}>
-            Link to NCBI BLAST:{' '}
-            <a target="_blank" href={link} rel="noreferrer">
-              {link2}
-            </a>
+          <div className={classes.ncbiLink}>
+            Link to NCBI BLAST: <ExternalLink href={link}>{link2}</ExternalLink>
           </div>
         ) : null}
 

--- a/src/LaunchMsaView/components/NCBIBlastQuery/NCBIBlastPanel.tsx
+++ b/src/LaunchMsaView/components/NCBIBlastQuery/NCBIBlastPanel.tsx
@@ -1,8 +1,14 @@
 import React, { useState } from 'react'
 
+import { useLocalStorage } from '@jbrowse/core/util'
+import SettingsIcon from '@mui/icons-material/Settings'
+import { IconButton } from '@mui/material'
+
 import NCBIBlastAutomaticPanel from './NCBIBlastAutomaticPanel'
 import NCBIBlastManualPanel from './NCBIBlastManualPanel'
 import NCBIBlastMethodSelector from './NCBIBlastMethodSelector'
+import NCBISettingsDialog from './NCBISettingsDialog'
+import { BASE_BLAST_URL } from './consts'
 
 import type { AbstractTrackModel, Feature } from '@jbrowse/core/util'
 
@@ -16,13 +22,30 @@ export default function NCBIBlastPanel({
   feature: Feature
 }) {
   const [lookupMethod, setLookupMethod] = useState('automatic')
+  const [baseUrl, setBaseUrl] = useLocalStorage(
+    'msa-blastRootUrl',
+    BASE_BLAST_URL,
+  )
+  const [settingsOpen, setSettingsOpen] = useState(false)
+
   return (
     <>
+      <IconButton
+        style={{ float: 'right' }}
+        size="small"
+        onClick={() => {
+          setSettingsOpen(true)
+        }}
+      >
+        <SettingsIcon />
+      </IconButton>
+
       {lookupMethod === 'automatic' ? (
         <NCBIBlastAutomaticPanel
           model={model}
           feature={feature}
           handleClose={handleClose}
+          baseUrl={baseUrl}
         >
           <NCBIBlastMethodSelector
             lookupMethod={lookupMethod}
@@ -35,12 +58,24 @@ export default function NCBIBlastPanel({
           model={model}
           feature={feature}
           handleClose={handleClose}
+          baseUrl={baseUrl}
         >
           <NCBIBlastMethodSelector
             lookupMethod={lookupMethod}
             setLookupMethod={setLookupMethod}
           />
         </NCBIBlastManualPanel>
+      ) : null}
+      {settingsOpen ? (
+        <NCBISettingsDialog
+          baseUrl={baseUrl}
+          handleClose={arg => {
+            if (arg) {
+              setBaseUrl(arg)
+            }
+            setSettingsOpen(false)
+          }}
+        />
       ) : null}
     </>
   )

--- a/src/LaunchMsaView/components/NCBIBlastQuery/NCBISettingsDialog.tsx
+++ b/src/LaunchMsaView/components/NCBIBlastQuery/NCBISettingsDialog.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react'
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from '@mui/material'
+
+import { BASE_BLAST_URL } from './consts'
+import TextField2 from '../../../TextField2'
+
+export default function NCBISettingsDialog({
+  handleClose,
+  baseUrl,
+}: {
+  handleClose: (arg?: string) => void
+  baseUrl: string
+}) {
+  const [tempBaseUrl, setTempBaseUrl] = useState(baseUrl)
+  return (
+    <Dialog
+      open
+      maxWidth="lg"
+      onClose={() => {
+        handleClose()
+      }}
+    >
+      <DialogTitle>BLAST Settings</DialogTitle>
+      <DialogContent>
+        <TextField2
+          autoFocus
+          margin="dense"
+          label="BLAST Base URL"
+          fullWidth
+          variant="outlined"
+          value={tempBaseUrl}
+          style={{ minWidth: '300px' }}
+          onChange={e => {
+            setTempBaseUrl(e.target.value)
+          }}
+        />
+        <Button
+          variant="contained"
+          onClick={() => {
+            setTempBaseUrl(BASE_BLAST_URL)
+          }}
+        >
+          Reset
+        </Button>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={() => {
+            handleClose()
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          color="primary"
+          variant="contained"
+          onClick={() => {
+            handleClose(tempBaseUrl)
+          }}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/LaunchMsaView/components/NCBIBlastQuery/blastLaunchView.ts
+++ b/src/LaunchMsaView/components/NCBIBlastQuery/blastLaunchView.ts
@@ -3,14 +3,16 @@ import { Feature, getSession } from '@jbrowse/core/util'
 import type { JBrowsePluginMsaViewModel } from '../../../MsaViewPanel/model'
 import type { LinearGenomeViewModel } from '@jbrowse/plugin-linear-genome-view'
 
-export function ncbiBlastLaunchView({
+export function blastLaunchView({
   newViewTitle,
   view,
   feature,
+  blastParams,
 }: {
   newViewTitle: string
   view: LinearGenomeViewModel
   feature: Feature
+  blastParams: Record<string, unknown>
 }) {
   return getSession(view).addView('MsaView', {
     type: 'MsaView',
@@ -20,5 +22,6 @@ export function ncbiBlastLaunchView({
     drawNodeBubbles: true,
     colWidth: 10,
     rowHeight: 12,
+    blastParams,
   }) as JBrowsePluginMsaViewModel
 }

--- a/src/LaunchMsaView/components/NCBIBlastQuery/consts.ts
+++ b/src/LaunchMsaView/components/NCBIBlastQuery/consts.ts
@@ -1,0 +1,1 @@
+export const BASE_BLAST_URL = 'https://blast.ncbi.nlm.nih.gov/Blast.cgi'

--- a/src/LaunchMsaView/components/TranscriptSelector.tsx
+++ b/src/LaunchMsaView/components/TranscriptSelector.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from 'tss-react/mui'
 
 import TextField2 from '../../TextField2'
 import {
-  getGeneDisplayName2,
+  getGeneDisplayName,
   getId,
   getTranscriptDisplayName,
   getTranscriptLength,
@@ -41,10 +41,10 @@ export default function TranscriptSelector({
 
   return (
     <>
-      <div style={{ display: 'inline' }}>
+      <div style={{ display: 'flex' }}>
         <TextField2
           variant="outlined"
-          label={`Choose isoform of ${getGeneDisplayName2(feature)}`}
+          label={`Choose isoform of ${getGeneDisplayName(feature)}`}
           select
           style={{ minWidth: 300 }}
           value={selectedTranscriptId}

--- a/src/LaunchMsaView/util.ts
+++ b/src/LaunchMsaView/util.ts
@@ -41,14 +41,6 @@ export function getTranscriptDisplayName(val?: Feature) {
 export function getGeneDisplayName(val?: Feature) {
   return val === undefined
     ? ''
-    : [val.get('gene_name') ?? val.get('name'), val.get('id')]
-        .filter(f => !!f)
-        .join(' ')
-}
-
-export function getGeneDisplayName2(val?: Feature) {
-  return val === undefined
-    ? ''
     : [
         val.get('gene_name') ?? val.get('name'),
         val.get('id') ? `(${val.get('id')})` : '',

--- a/src/MsaViewPanel/components/LoadingBLAST.tsx
+++ b/src/MsaViewPanel/components/LoadingBLAST.tsx
@@ -17,20 +17,36 @@ const useStyles = makeStyles()(theme => ({
   },
 }))
 
-function RIDError({ rid, error }: { rid?: string; error: unknown }) {
+function RIDError({
+  baseUrl,
+  rid,
+  error,
+}: {
+  baseUrl: string
+  rid?: string
+  error: unknown
+}) {
   return (
     <div>
-      {rid ? <RIDLink rid={rid} /> : null}
+      {rid ? <RIDLink rid={rid} baseUrl={baseUrl} /> : null}
       <ErrorMessage error={error} />
     </div>
   )
 }
 
-function RIDProgress({ rid, progress }: { rid: string; progress: string }) {
+function RIDProgress({
+  baseUrl,
+  rid,
+  progress,
+}: {
+  baseUrl: string
+  rid: string
+  progress: string
+}) {
   const { classes } = useStyles()
   return (
     <div className={classes.loading}>
-      {rid ? <RIDLink rid={rid} /> : null}
+      {rid ? <RIDLink baseUrl={baseUrl} rid={rid} /> : null}
       <Typography>{progress}</Typography>
     </div>
   )
@@ -38,8 +54,10 @@ function RIDProgress({ rid, progress }: { rid: string; progress: string }) {
 
 const LoadingBLAST = observer(function LoadingBLAST2({
   model,
+  baseUrl,
 }: {
   model: JBrowsePluginMsaViewModel
+  baseUrl: string
 }) {
   const { progress, rid, error, processing } = model
   const { classes } = useStyles()
@@ -47,10 +65,10 @@ const LoadingBLAST = observer(function LoadingBLAST2({
     <div className={classes.margin}>
       <LoadingEllipses message="Running NCBI BLAST" variant="h5" />
       {error ? (
-        <RIDError rid={rid} error={error} />
-      ) : (rid ? (
-        <RIDProgress rid={rid} progress={progress} />
-      ) : null)}
+        <RIDError baseUrl={baseUrl} rid={rid} error={error} />
+      ) : rid ? (
+        <RIDProgress baseUrl={baseUrl} rid={rid} progress={progress} />
+      ) : null}
       <Typography>{processing || 'Initializing BLAST query'}</Typography>
     </div>
   )

--- a/src/MsaViewPanel/components/MsaViewPanel.tsx
+++ b/src/MsaViewPanel/components/MsaViewPanel.tsx
@@ -14,7 +14,11 @@ const MsaViewPanel = observer(function MsaViewPanel2({
   const { blastParams } = model
   return (
     <div>
-      {blastParams ? <LoadingBLAST model={model} /> : <MSAView model={model} />}
+      {blastParams ? (
+        <LoadingBLAST model={model} baseUrl={blastParams.baseUrl} />
+      ) : (
+        <MSAView model={model} />
+      )}
     </div>
   )
 })

--- a/src/MsaViewPanel/components/RIDLink.tsx
+++ b/src/MsaViewPanel/components/RIDLink.tsx
@@ -3,14 +3,13 @@ import React from 'react'
 import { Typography } from '@mui/material'
 
 import ExternalLink from '../../ExternalLink'
-import { BLAST_URL } from '../../utils/ncbiBlast'
 
-function RIDLink({ rid }: { rid: string }) {
+function RIDLink({ baseUrl, rid }: { rid: string; baseUrl: string }) {
   return (
     <Typography>
       RID {rid} (
-      <ExternalLink href={`${BLAST_URL}?CMD=Get&RID=${rid}`}>
-        see status at NCBI
+      <ExternalLink href={`${baseUrl}?CMD=Get&RID=${rid}`}>
+        see status
       </ExternalLink>
       )
     </Typography>

--- a/src/MsaViewPanel/model.ts
+++ b/src/MsaViewPanel/model.ts
@@ -24,6 +24,7 @@ export interface IRegion {
 }
 
 export interface BlastParams {
+  baseUrl: string
   blastDatabase: string
   msaAlgorithm: string
   blastProgram: string

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -15,9 +15,9 @@ export async function textfetch(url: string, args?: RequestInit) {
   return response.text()
 }
 
-export async function jsonfetch(url: string, args?: RequestInit) {
+export async function jsonfetch<T>(url: string, args?: RequestInit) {
   const response = await myfetch(url, args)
-  return response.json()
+  return response.json() as Promise<T>
 }
 
 export function timeout(time: number) {

--- a/src/utils/ncbiBlast.ts
+++ b/src/utils/ncbiBlast.ts
@@ -1,18 +1,18 @@
 import { jsonfetch, textfetch, timeout } from './fetch'
 import { BlastResults } from './types'
 
-export const BLAST_URL = `https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi`
-
 export async function queryBlast({
   query,
   blastDatabase,
   blastProgram,
+  baseUrl,
   onProgress,
   onRid,
 }: {
   query: string
   blastDatabase: string
   blastProgram: string
+  baseUrl: string
   onProgress: (arg: string) => void
   onRid: (arg: string) => void
 }) {
@@ -21,14 +21,16 @@ export async function queryBlast({
     query,
     blastDatabase,
     blastProgram,
+    baseUrl,
   })
   onRid(rid)
   await waitForRid({
     rid,
     onProgress,
+    baseUrl,
   })
   const ret = await jsonfetch<BlastResults>(
-    `${BLAST_URL}?CMD=Get&RID=${rid}&FORMAT_TYPE=JSON2_S&FORMAT_OBJECT=Alignment`,
+    `${baseUrl}?CMD=Get&RID=${rid}&FORMAT_TYPE=JSON2_S&FORMAT_OBJECT=Alignment`,
   )
   return {
     rid,
@@ -40,12 +42,14 @@ async function initialQuery({
   query,
   blastProgram,
   blastDatabase,
+  baseUrl,
 }: {
   query: string
   blastProgram: string
   blastDatabase: string
+  baseUrl: string
 }) {
-  const res = await textfetch(BLAST_URL, {
+  const res = await textfetch(baseUrl, {
     method: 'POST',
     body: new URLSearchParams({
       CMD: 'Put',
@@ -82,9 +86,11 @@ async function initialQuery({
 async function waitForRid({
   rid,
   onProgress,
+  baseUrl,
 }: {
   rid: string
   onProgress: (arg: string) => void
+  baseUrl: string
 }) {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   while (true) {
@@ -95,7 +101,7 @@ async function waitForRid({
     }
 
     const res = await textfetch(
-      `${BLAST_URL}?CMD=Get&FORMAT_OBJECT=SearchInfo&RID=${rid}`,
+      `${baseUrl}?CMD=Get&FORMAT_OBJECT=SearchInfo&RID=${rid}`,
     )
     const isWaiting = /\s+Status=WAITING/m.test(res)
     const isFailed = /\s+Status=FAILED/m.test(res)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,14 @@
+export interface BlastResults {
+  BlastOutput2: {
+    report: {
+      results: {
+        search: {
+          hits: {
+            description: { accession: string; id: string; sciname: string }[]
+            hsps: { hseq: string }[]
+          }[]
+        }
+      }
+    }
+  }[]
+}


### PR DESCRIPTION
the quick-blastp option can run significantly faster (e.g. 30 seconds instead of 15 minutes)

quick-blastp cannot be used on the nr_clustered database so it just finds close and sometimes redundant hits